### PR TITLE
acobster — Fixes bug preventing creation of new Retina crops

### DIFF
--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -336,7 +336,7 @@ class ManualImageCrop {
 		}
 
 		// Generate Retina Image
-		if( isset( $data['make2x'] ) && $data['make2x'] === 'true' ) {
+		if( isset( $data['make2x'] ) && $data['make2x'] === true ) {
 			$dst_w2x = $dst_w * 2;
 			$dst_h2x = $dst_h * 2;
 


### PR DESCRIPTION
From tomaszsita/wp-manual-image-crop#66:

> Fixes [#65](https://github.com/tomaszsita/wp-manual-image-crop/issues/65)
